### PR TITLE
Fix import conflict in COLLECT LINKS page

### DIFF
--- a/pages/COLLECT LINKS.py
+++ b/pages/COLLECT LINKS.py
@@ -1,11 +1,6 @@
 import os
 import streamlit as st
 import pandas as pd
-import os
-<<<<<<< HEAD
-from extract_links import extract_all_vehicle_links
-=======
->>>>>>> 4cb049be (Your commit message)
 from scripts.extract_links import extract_all_vehicle_links
 
 st.set_page_config(page_title="Extract All Vehicle Links", layout="wide")


### PR DESCRIPTION
## Summary
- clean up merge conflict markers in `pages/COLLECT LINKS.py`
- keep the correct `scripts.extract_links` import and remove the duplicate `os` import

## Testing
- `python -m py_compile 'pages/COLLECT LINKS.py'`


------
https://chatgpt.com/codex/tasks/task_e_68c939a275a8832d8260c8c8ae353122