### PR TITLE
Adjust year matching for link extraction

### DIFF
--- a/scripts/extract_links.py
+++ b/scripts/extract_links.py
@@ -53,7 +53,7 @@ def extract_all_vehicle_links(return_progress=False):
         for a in soup.find_all("a", href=True):
             href = a["href"]
             text = a.get_text(strip=True)
-            if re.search(r"/lot/\d+", href) and re.match(r"^\d{4}\b", text):
+            if re.search(r"/lot/\d+", href) and re.search(r"\b\d{4}\b", text):
                 if "motorbike" in text.lower() or "motor bike" in text.lower():
                     continue
                 full_url = "https://www.grays.com" + href if href.startswith("/") else href


### PR DESCRIPTION
## Summary
- Update the link extractor to accept four-digit years anywhere in the anchor text, improving lot detection

## Testing
- python scripts/extract_links.py *(fails: HTTPS proxy blocks external request)*

------
https://chatgpt.com/codex/tasks/task_e_68c93dd003d8832d8dc69e4ad8c50668