### PR TITLE
Handle missing pandas dependency in extract script

### DIFF
--- a/scripts/extract_vehicle_details.py
+++ b/scripts/extract_vehicle_details.py
@@ -1,11 +1,18 @@
 import asyncio
 import os
 import re
-import pandas as pd
-from bs4 import BeautifulSoup
-from playwright.async_api import async_playwright
+import sys
 import tempfile
 import shutil
+
+from bs4 import BeautifulSoup
+from playwright.async_api import async_playwright
+
+try:
+    import pandas as pd
+except ModuleNotFoundError:
+    print("Install with `pip install -r requirements.txt`")
+    sys.exit(1)
 
 # ─── File Paths ────────────────────────────────────────────────
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## Summary
- add a guarded import for pandas so the extraction script exits cleanly when the dependency is missing

## Testing
- python - <<'PY'
import builtins
import runpy

orig_import = builtins.__import__

def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
    if name == "pandas":
        raise ModuleNotFoundError("No module named 'pandas'")
    return orig_import(name, globals, locals, fromlist, level)

builtins.__import__ = fake_import
try:
    runpy.run_path('scripts/extract_vehicle_details.py', run_name='__main__')
finally:
    builtins.__import__ = orig_import
PY

------
https://chatgpt.com/codex/tasks/task_e_68cb8af67f4c832dbad7a97186497e43