### PR TITLE
Improve BeautifulSoup import error handling

### DIFF
--- a/scripts/extract_vehicle_details.py
+++ b/scripts/extract_vehicle_details.py
@@ -7,8 +7,12 @@ import shutil
 
 try:
     from bs4 import BeautifulSoup
-except ModuleNotFoundError:
-    print("BeautifulSoup is required. Install with `pip install -r requirements.txt`.")
+except ModuleNotFoundError as exc:
+    if getattr(exc, "name", None) == "bs4":
+        print("BeautifulSoup is required. Install with `pip install -r requirements.txt`.")
+    else:
+        missing_module = getattr(exc, "name", str(exc))
+        print(f"Failed to import required module: {missing_module}")
     sys.exit(1)
 
 from playwright.async_api import async_playwright


### PR DESCRIPTION
## Summary
- capture `ModuleNotFoundError` details when importing BeautifulSoup
- retain the existing message when bs4 itself is missing and expose other missing dependencies
- ensure the script exits with a non-zero status after logging the import failure

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb9abda21c832d9a514cebedfd901a