### PR TITLE
Add --urls flag to bid update command

### DIFF
--- a/pages/viable_listings.py
+++ b/pages/viable_listings.py
@@ -108,10 +108,15 @@ if st.button("Refresh Selected"):
     else:
         with st.spinner("Updating selected listings..."):
             try:
-                subprocess.run(
-                    ["python", "scripts/update_bids.py", *selected_urls],
+                result = subprocess.run(
+                    ["python", "scripts/update_bids.py", "--urls", *selected_urls],
                     check=True,
+                    capture_output=True,
+                    text=True,
                 )
                 st.success("✅ Selected listings refreshed.")
+                if result.stdout:
+                    st.text(result.stdout)
             except subprocess.CalledProcessError as e:
-                st.error(f"❌ Update failed: {e}")
+                error_message = e.stderr or e.stdout or str(e)
+                st.error(f"❌ Update failed: {error_message}")


### PR DESCRIPTION
## Summary
- update the viable listings page to pass the --urls flag when invoking the bid refresher script
- capture subprocess output so Streamlit can surface success messages or detailed errors

## Testing
- python scripts/update_bids.py --urls https://example.com --file /tmp/test.csv *(fails: Playwright browser binaries not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe0b74318832da250b31c079d7320